### PR TITLE
Update dependencies and undefine the required LFE version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,11 +7,11 @@
 {deps, [
    {lfe, "0.9.0", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.0"}}},
    {lutil, ".*", {git, "https://github.com/lfex/lutil.git", {tag, "0.6.1"}}},
-   {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.4.0"}}},
-   {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", {tag, "0.13.2"}}},
-   {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.1.1"}}},
+   {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.4.2"}}},
+   {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", {tag, "0.13.3"}}},
+   {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.4.0"}}},
    {mochiweb, ".*", {git,
-     "git://github.com/mochi/mochiweb.git", {tag, "v2.9.2"}}},
+     "git://github.com/mochi/mochiweb.git", {tag, "v2.12.0"}}},
    {ej, ".*", {git,
      "git://github.com/seth/ej.git", "c683084665e1220616e611639fb13797b91281c6"}}
   ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,7 @@
   ]}.
 {deps, [
    {lfe, "0.9.0", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.0"}}},
-   %%{lutil, ".*", {git, "https://github.com/lfex/lutil.git", {tag, "0.4.1"}}},
-   {lutil, ".*", {git, "https://github.com/thorgisl/lutil.git", "master"}},
+   {lutil, ".*", {git, "https://github.com/lfex/lutil.git", {tag, "0.6.1"}}},
    {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.4.0"}}},
    {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", {tag, "0.13.2"}}},
    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.1.1"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
    {src_dirs, ["test"]}
   ]}.
 {deps, [
-   {lfe, "0.9.0", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.0"}}},
+   {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.0"}}},
    {lutil, ".*", {git, "https://github.com/lfex/lutil.git", {tag, "0.6.1"}}},
    {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.4.2"}}},
    {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", {tag, "0.13.3"}}},


### PR DESCRIPTION
Hi,

In order to get ljson and lcfg to work together I had to undefine the required LFE version that ljson specifies. I also updated all the dependencies to their latests versions and switched the lutil repo to point to the upstream one.
